### PR TITLE
Fixed format priority for books in multiple formats

### DIFF
--- a/etc/features.py
+++ b/etc/features.py
@@ -5,13 +5,12 @@
 #
 
 # The default supported book formats are (in this order):
-#   [ 'MOBI', 'AZW', 'PRC', 'PDF' ]
+#supported_formats = [ 'MOBI', 'AZW', 'PRC', 'PDF' ]
 # If you want to only serve a subset of these, set this option (case does not matter).
 # NOTE: when multiple supported formats are available for a book, only the first one in the list above will be served to the kindle device.
 # Also, if you download a book in one format, then another format with a higher priority appears for that book,
 #   you'll just confuse the hell out of the kindle...
 # NOTE: KSP will only 'see' MOBI books with the proper ASIN tag -- see docs/library.md for details.
-#supported_formats = [ 'mobi' ]
 
 # New revisions of books are automatically downloaded by the device.
 # WARNING: updating a book file on the device will reset the last-read-position, and delete the notes and highlights for the book!

--- a/src/calibre/book.py
+++ b/src/calibre/book.py
@@ -1,6 +1,6 @@
 import os.path, logging
 
-import config, formats
+import config, formats, features
 
 
 class Book:
@@ -39,7 +39,7 @@ class Book:
 			logging.debug("book updated %s", self)
 
 	def _ebook_file(self, book_path, files_dict):
-		for format, content_type in formats.CONTENT_TYPES.items():
+		for format in features.supported_formats:
 			name = files_dict.get(format)
 			if not name:
 				continue
@@ -54,6 +54,7 @@ class Book:
 				# we're doing an update of an already-loaded book, and the file did not change
 				return
 
+			content_type = formats.CONTENT_TYPES[format]
 			if formats.handles(content_type):
 				cde_type = formats.read_cde_type(path, content_type, self.asin)
 				if not cde_type:


### PR DESCRIPTION
Whenever a book was available both in mobi and pdf, KSP on my machine would serve a pdf version. The priority depended on order of items in the dict formats.CONTENT_TYPES, which is undefined.

features.supported_formats controls now which formats can be served and their order of preference.
