### PR TITLE
Fix order of archived items when sorted by author

### DIFF
--- a/src/calibre/db.py
+++ b/src/calibre/db.py
@@ -89,7 +89,7 @@ def reload_all():
 			books[row['id']] = _book_dict(row)
 
 		_update_book_list(c, books, 'authors',
-				"select books_authors_link.book, authors.name from books_authors_link, authors"
+				"select books_authors_link.book, authors.sort from books_authors_link, authors"
 					" where books_authors_link.author = authors.id")
 		_update_book_list(c, books, 'publishers',
 				"select books_publishers_link.book, publishers.name from books_publishers_link, publishers"


### PR DESCRIPTION
In the book listing sent by Amazon, authors are listed as
`<author>LastName, FirstName</author>`
Kindle still displays authors starting with the first name, but books are ordered by the last name.
